### PR TITLE
Add super-linter workflow and docs for local linting

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,52 @@
+name: Code Quality
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Lint Code Base
+        uses: github/super-linter@v6
+        env:
+          VALIDATE_PYTHON: true
+          VALIDATE_JAVA: true
+          VALIDATE_JAVASCRIPT: true
+          VALIDATE_SCALA: true
+          VALIDATE_SQL: true
+          VALIDATE_JSON: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -46,3 +46,21 @@ model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
 
 For serving, any MLflow tooling such as `mlflow models serve` can be used to expose the registered model as a REST API.
 
+
+## Running super-linter locally
+
+Developers can run the same checks locally using Docker:
+
+```bash
+docker run \
+  -e RUN_LOCAL=true \
+  -e VALIDATE_PYTHON=true \
+  -e VALIDATE_JAVA=true \
+  -e VALIDATE_JAVASCRIPT=true \
+  -e VALIDATE_SCALA=true \
+  -e VALIDATE_SQL=true \
+  -e VALIDATE_JSON=true \
+  -v "$PWD:/tmp/lint" \
+  ghcr.io/github/super-linter:slim-latest
+```
+


### PR DESCRIPTION
## Summary
- add code-quality workflow running GitHub super-linter with language caches
- document how to run super-linter locally via Docker

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'train_wti_mlflow_fallback')*

------
https://chatgpt.com/codex/tasks/task_e_68b04fd611a883268a15bca4e152cac3